### PR TITLE
feat: Auto refresh/poll requests

### DIFF
--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -8,6 +8,9 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import BinRequest from "../../components/BinRequest";
 import { RequestDetails, RequestListResponse } from "../../utils/interfaces";
+import useInterval from "@/hooks/useInterval";
+
+const POLL_INTERVAL = 5000;
 
 const Bin = () => {
   const router = useRouter();
@@ -48,6 +51,30 @@ const Bin = () => {
     setRequests(data);
     setIsRefreshing(false);
   };
+
+  useInterval(async () => {
+    const { signal, abort } = new AbortController();
+
+    const promises = [
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/bins/${binId}/requests`, {
+        signal,
+      }),
+      new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL)),
+    ];
+
+    // To prevent requests from stacking up if the request takes longer than the interval to complete,
+    // the request is cancelled if it's still running
+    const result = await Promise.race(promises);
+
+    if (result instanceof Response && result.ok) {
+      const data = (await result.json()) as RequestListResponse;
+      setRequests(data);
+    } else {
+      abort();
+    }
+
+    return () => abort();
+  }, POLL_INTERVAL);
 
   const getRequestData = async (requestId: string) => {
     setIsLoading(true);

--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -64,7 +64,9 @@ const Bin = () => {
 
     // To prevent requests from stacking up if the request takes longer than the interval to complete,
     // the request is cancelled if it's still running
-    const result = await Promise.race(promises);
+    const result = await Promise.race(promises).catch(() => {
+      // Fail silently in case of a network error
+    });
 
     if (result instanceof Response && result.ok) {
       const data = (await result.json()) as RequestListResponse;

--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -53,11 +53,11 @@ const Bin = () => {
   };
 
   useInterval(async () => {
-    const { signal, abort } = new AbortController();
+    const controller = new AbortController();
 
     const promises = [
       fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/bins/${binId}/requests`, {
-        signal,
+        signal: controller.signal,
       }),
       new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL)),
     ];
@@ -72,10 +72,10 @@ const Bin = () => {
       const data = (await result.json()) as RequestListResponse;
       setRequests(data);
     } else {
-      abort();
+      controller.abort();
     }
 
-    return () => abort();
+    return () => controller.abort();
   }, POLL_INTERVAL);
 
   const getRequestData = async (requestId: string) => {


### PR DESCRIPTION
This enables auto refresh/polling for requests, which seems like an intuitive addition. I've also added a guard that cancels a request if it doesn't go through in the interval time, so the requests won't pile up. 
For now, it just re-fetches all of the requests, this could be further optimised by cursor-based fetching or something like having a "last request incoming" time.