### PR TITLE
feat: Request overview revamp

### DIFF
--- a/www/components/ArrowIcon.tsx
+++ b/www/components/ArrowIcon.tsx
@@ -1,0 +1,18 @@
+const ArrowIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="lucide lucide-chevron-right"
+  >
+    <path d="m9 18 6-6-6-6" />
+  </svg>
+);
+
+export default ArrowIcon;

--- a/www/components/BinHeader.tsx
+++ b/www/components/BinHeader.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import Image from "next/image";
+import HeaderImage from "@/public/mockbin-header.png";
+import CopyButton from "@/components/CopyButton";
+import SelectOnClick from "@/components/SelectOnClick";
+import RefreshIcon from "@/components/RefreshIcon";
+
+const BinHeader = ({
+  binUrl,
+  onRefresh,
+}: {
+  binUrl: string;
+  onRefresh: () => void;
+}) => (
+  <header className="h-[60px] sticky top-0 flex bg-[#000019] items-center">
+    <Link href="/">
+      <Image alt="mockbin logo" height={60} src={HeaderImage} />
+    </Link>
+    <div className="flex-grow px-4 py-2 flex items-center gap-2 text-sm">
+      Your bin is live at
+      <SelectOnClick>
+        <code className="bg-slate-800 rounded border border-slate-700 bg px-2 py-1 text-[#FF00BD]">
+          {binUrl}
+        </code>
+      </SelectOnClick>
+      <CopyButton textToCopy={binUrl} />
+    </div>
+    <button className="px-4" onClick={onRefresh}>
+      <RefreshIcon />
+    </button>
+  </header>
+);
+export default BinHeader;

--- a/www/components/BinRequest.tsx
+++ b/www/components/BinRequest.tsx
@@ -1,15 +1,18 @@
 import CopyButton from "@/components/CopyButton";
 import Tabs, { Tab } from "@/components/Tabs";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { RequestDetails } from "../utils/interfaces";
+import { getMethodTextColor } from "@/components/MethodIndicator";
+import CloseIcon from "@/components/CloseIcon";
 
 type TestOperationResponseProps = {
   isLoading: boolean;
   requestDetails: RequestDetails | undefined;
+  onClose: () => void;
 };
 
 const FloatingCopyButton = ({ textToCopy }: { textToCopy: string }) => (
-  <div className="hidden sm:block absolute right-4 pt-2 z-50">
+  <div className="hidden sm:block absolute right-4 z-40">
     <CopyButton textToCopy={textToCopy} />
   </div>
 );
@@ -41,14 +44,13 @@ const getRequestIsJson = (requestDetails: RequestDetails | undefined) => {
 const BinRequest = ({
   isLoading,
   requestDetails,
+  onClose,
 }: TestOperationResponseProps) => {
+  const requestIsJson =
+    !isLoading && requestDetails ? getRequestIsJson(requestDetails) : false;
   const tabs: Tab[] = [
-    {
-      name: "RAW",
-    },
-    {
-      name: "JSON",
-    },
+    { name: "RAW" },
+    ...(requestIsJson ? [{ name: "JSON" }] : []),
     {
       name: "HEADERS",
       count: requestDetails?.headers
@@ -57,13 +59,13 @@ const BinRequest = ({
     },
   ];
 
-  const requestIsJson =
-    !isLoading && requestDetails ? getRequestIsJson(requestDetails) : false;
-  const [selectedTab, setSelectedTab] = useState("RAW");
+  const [selectedTab, setSelectedTab] = useState(
+    requestIsJson ? "JSON" : "RAW",
+  );
 
   useEffect(() => {
     setSelectedTab(requestIsJson ? "JSON" : "RAW");
-  }, [requestDetails]);
+  }, [requestIsJson]);
 
   let requestUrl = null;
   if (requestDetails?.url) {
@@ -71,41 +73,40 @@ const BinRequest = ({
   }
 
   if (isLoading) {
-    return <p>Loading...</p>;
+    return (
+      <div className="flex justify-center translate-y-[250px]">Loading...</div>
+    );
   }
 
   if (!requestDetails) {
     return <p>Click on a request to see its details here</p>;
   }
 
+  const requestBody = requestDetails.body
+    ? requestIsJson && selectedTab === "JSON"
+      ? JSON.stringify(JSON.parse(requestDetails.body), null, 2)
+      : requestDetails.body
+    : undefined;
+
   return (
-    <div className="sticky top-4 flex flex-col h-fit w-full border border-input-border rounded-md pt-4 mb-4">
-      <div className="flex flex-col sm:flex-row px-4 pb-3 gap-x-4 text-md sm:text-lg">
-        <div className="flex gap-x-1">
-          <span>METHOD: </span>
-          <span className="font-mono px-1">{requestDetails?.method}</span>
-        </div>
-        <div className="flex gap-x-1">
-          <span>TIME: </span>
-          <span className="font-mono">
-            {requestDetails?.timestamp ? `${requestDetails.timestamp}` : null}
-          </span>
-        </div>
-        <div className="flex gap-x-1">
-          <span>SIZE: </span>
-          <span className="font-mono">
-            {requestDetails?.size != null ? `${requestDetails.size} B` : null}
-          </span>
-        </div>
+    <div className="flex flex-col h-full">
+      <div className="flex gap-2 border-b sticky top-0 bg-slate-950 z-50 border-slate-800 p-4">
+        <span
+          className={`font-bold ${getMethodTextColor(requestDetails.method)}`}
+        >
+          {requestDetails.method}
+        </span>
+        <pre className="flex-grow">{requestUrl}</pre>
+        <button onClick={onClose}>
+          <CloseIcon />
+        </button>
       </div>
-      <div className="flex flex-col sm:flex-row px-4 pb-3 gap-x-4 text-md sm:text-lg">
-        <div className="flex gap-x-1">
-          <span>PATH: </span>
-          <span className="break-all">{requestUrl}</span>
-        </div>
+      <div className="flex px-4 py-2 gap-1 text-slate-600">
+        Request time: {new Date(requestDetails.timestamp).toLocaleString()},
+        size: {requestDetails.size} B
       </div>
       <div>
-        <div className="border-b border-input-border">
+        <div className="border-b border-slate-800">
           <div className="px-3 sm:px-4">
             <Tabs
               selectedTab={selectedTab}
@@ -115,43 +116,22 @@ const BinRequest = ({
           </div>
         </div>
       </div>
-      <div className="flex my-4 h-full">
-        {selectedTab === "RAW" ? (
-          <div className="flex relative w-full h-full">
-            <code className="flex items-center h-full w-full overflow-x-auto break-words px-2 whitespace-pre text-sm sm:text-lg pl-5">
-              {requestDetails.body ?? "No body was sent in the request"}
-            </code>
-            {requestDetails.body ? (
-              <FloatingCopyButton textToCopy={requestDetails.body} />
-            ) : null}
-          </div>
-        ) : null}
-        {selectedTab === "JSON" ? (
-          <div className="flex relative w-full h-full">
-            {requestDetails.body === null ? (
-              <code className="flex items-center h-full w-full overflow-x-auto break-words px-2 whitespace-pre text-sm sm:text-lg pl-5">
-                No body was sent in the request
-              </code>
+      <div className="m-4">
+        {(selectedTab === "RAW" || selectedTab === "JSON") && (
+          <div className="flex overflow-x-auto overflow-y-clip">
+            {requestBody ? (
+              <code className="whitespace-pre">{requestBody}</code>
             ) : (
-              <code className="flex items-center h-full w-fit overflow-x-auto break-words px-2 whitespace-pre text-sm sm:text-lg">
-                {requestIsJson
-                  ? // Formats JSON response with 2 spaces
-                    JSON.stringify(JSON.parse(requestDetails.body), null, 2)
-                  : "Request body is not JSON. Click 'RAW' to see request body"}
-              </code>
+              <span className="italic">No request body sent.</span>
             )}
-            {requestIsJson && requestDetails.body ? (
-              <FloatingCopyButton
-                textToCopy={JSON.stringify(
-                  JSON.parse(requestDetails.body),
-                  null,
-                  2,
-                )}
-              />
-            ) : null}
+            {requestBody && (
+              <div className="relative w-full">
+                <FloatingCopyButton textToCopy={requestBody} />
+              </div>
+            )}
           </div>
-        ) : null}
-        {selectedTab === "HEADERS" ? (
+        )}
+        {selectedTab === "HEADERS" && (
           <table className="text-sm mx-4 border-collapse h-full table-auto">
             <tr>
               <th className="text-left border border-input-border px-2">
@@ -161,22 +141,21 @@ const BinRequest = ({
                 VALUE
               </th>
             </tr>
-            {requestDetails.headers
-              ? Object.entries(requestDetails.headers).map(([key, value]) => {
-                  return (
-                    <tr className="font-mono" key={key}>
-                      <td className="text-left border border-input-border px-2">
-                        {key}
-                      </td>
-                      <td className="text-left whitespace-pre-line break-all border border-input-border px-2">
-                        {value}
-                      </td>
-                    </tr>
-                  );
-                })
-              : null}
+            {requestDetails.headers &&
+              Object.entries(requestDetails.headers).map(([key, value]) => {
+                return (
+                  <tr className="font-mono" key={key}>
+                    <td className="text-left border border-input-border px-2">
+                      {key}
+                    </td>
+                    <td className="text-left whitespace-pre-line break-all border border-input-border px-2">
+                      {value}
+                    </td>
+                  </tr>
+                );
+              })}
           </table>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/www/components/CloseIcon.tsx
+++ b/www/components/CloseIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const CloseIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="lucide lucide-x-circle"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="m15 9-6 6" />
+    <path d="m9 9 6 6" />
+  </svg>
+);
+
+export default CloseIcon;

--- a/www/components/MethodIndicator.tsx
+++ b/www/components/MethodIndicator.tsx
@@ -1,0 +1,46 @@
+export const getMethodBgColor = (method: string) => {
+  switch (method.toUpperCase()) {
+    case "GET":
+      return "bg-blue-700";
+    case "POST":
+      return "bg-green-700";
+    case "PATCH":
+      return "bg-amber-600";
+    case "PUT":
+      return "bg-purple-700";
+    case "DELETE":
+      return "bg-red-700";
+    default:
+      return "bg-gray-500";
+  }
+};
+
+export const getMethodTextColor = (method: string) => {
+  switch (method.toUpperCase()) {
+    case "GET":
+      return "text-blue-600";
+    case "POST":
+      return "text-green-600";
+    case "PATCH":
+      return "text-amber-500";
+    case "PUT":
+      return "text-purple-600";
+    case "DELETE":
+      return "text-red-500";
+    default:
+      return "text-gray-400";
+  }
+};
+
+const MethodIndicator = ({ method }: { method: string }) => {
+  const color = getMethodBgColor(method);
+
+  return (
+    <div className={`font-bold flex items-center gap-2`}>
+      <div className={`w-2 h-2 rounded-full ${color}`} />
+      {method.toUpperCase()}
+    </div>
+  );
+};
+
+export default MethodIndicator;

--- a/www/components/RefreshIcon.tsx
+++ b/www/components/RefreshIcon.tsx
@@ -1,0 +1,21 @@
+const RefreshIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="lucide lucide-refresh-cw"
+  >
+    <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+    <path d="M21 3v5h-5" />
+    <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+    <path d="M8 16H3v5" />
+  </svg>
+);
+
+export default RefreshIcon;

--- a/www/components/SelectOnClick.tsx
+++ b/www/components/SelectOnClick.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+
+const SelectOnClick = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <button
+    className={className}
+    onClick={(e) => {
+      const selection = window.getSelection();
+      const range = document.createRange();
+
+      range.selectNodeContents(e.currentTarget);
+
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }}
+  >
+    {children}
+  </button>
+);
+
+export default SelectOnClick;

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-config-next": "14.0.1",
         "postcss": "^8",
         "prettier": "^3.0.3",
-        "tailwindcss": "^3.3.0",
+        "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
     },
@@ -3958,9 +3958,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
-      "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/www/package.json
+++ b/www/package.json
@@ -26,7 +26,7 @@
     "eslint-config-next": "14.0.1",
     "postcss": "^8",
     "prettier": "^3.0.3",
-    "tailwindcss": "^3.3.0",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }
 }

--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -5,12 +5,37 @@ import { timeAgo } from "@/utils/helpers";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import cn from "classnames";
+import { useEffect, useState, type HTMLProps } from "react";
 import BinRequest from "../../components/BinRequest";
 import { RequestDetails, RequestListResponse } from "../../utils/interfaces";
 import useInterval from "@/hooks/useInterval";
+import MethodIndicator from "@/components/MethodIndicator";
+import BinHeader from "@/components/BinHeader";
+import SelectOnClick from "@/components/SelectOnClick";
+import ArrowIcon from "@/components/ArrowIcon";
 
 const POLL_INTERVAL = 5000;
+
+const Row = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "grid grid-cols-subgrid group col-span-full border-b border-slate-800 hover:bg-slate-800/50 hover:cursor-pointer",
+      className,
+    )}
+    {...props}
+  />
+);
+
+const Column = ({ className, ...props }: HTMLProps<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex items-center border-r last:border-r-0 border-slate-800 py-2 px-4",
+      className,
+    )}
+    {...props}
+  />
+);
 
 const Bin = () => {
   const router = useRouter();
@@ -81,7 +106,6 @@ const Bin = () => {
   const getRequestData = async (requestId: string) => {
     setIsLoading(true);
     setCurrentRequestId(requestId);
-    setCurrentRequest(undefined);
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_API_URL}/v1/bins/${binId}/requests/${requestId}`,
     );
@@ -114,65 +138,35 @@ const Bin = () => {
 
   const binUrl = requests.url ?? `${process.env.NEXT_PUBLIC_API_URL}/${binId}`;
   return (
-    <Frame>
-      <div className="text-md mb-8 mt-2 -ml-1">
-        <Link
-          className="text-[#FF00BD] hover:text-[#FF90E3] hover:bg-pink-500 hover:bg-opacity-50 rounded p-1"
-          href="/"
-        >
-          Home
-        </Link>{" "}
-        &rsaquo; <span className="font-mono">{binId}</span>
-      </div>
-      <div>
-        Your bin is live at <br />{" "}
-        <a
-          className="text-[#FF00BD] hover:text-[#FF90E3] break-all font-mono text-base hover:bg-pink-500 hover:bg-opacity-50 rounded p-1 -ml-1"
-          target="_blank"
-          href={binUrl}
-        >
-          {binUrl}
-        </a>
-        <span className="align-middle">
-          <CopyButton textToCopy={binUrl} />
-        </span>
-      </div>
-      <div className="flex justify-between items-end mt-8 sm:mt-20 mb-5">
-        <h1 className="font-bold text-3xl">Requests</h1>
-        <button
-          className="flex items-center justify-center border border-white rounded-md hover:border-[#FF00BD] hover:text-[#FF00BD] px-2 py-1"
-          onClick={() => {
-            getRequests();
-          }}
-        >
-          <div className={`mr-2 ${isRefreshing ? "animate-spin" : ""}`}>
-            <svg
-              className="h-4 w-4 scale-x-[-1]"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-          </div>
-          Refresh
-        </button>
-      </div>
+    <main>
+      <BinHeader binUrl={binUrl} onRefresh={() => getRequests()} />
       {requests.data.length === 0 ? (
-        <div>
-          No requests made to your bin. Click Refresh once you&apos;ve made
-          some.
+        <div className="flex items-center translate-y-[35vh] text-lg flex-col gap-8">
+          No requests made to your bin yet. Send a request to see it here.
+          <SelectOnClick>
+            <code className="text-md bg-slate-800 rounded border border-slate-700 p-4 flex items-center gap-2">
+              curl -X GET <span className="text-[#FF00BD]">{binUrl}</span>
+              <CopyButton textToCopy={`curl -X GET ${binUrl}`} />
+            </code>
+          </SelectOnClick>
         </div>
       ) : (
-        <div className="grid grid-cols-10">
-          <div className="flex flex-col col-span-3 mr-4">
-            <ul className="border border-gray-700 rounded-md">
+        <div className="flex border-t border-slate-800 text-sm h-[calc(100vh-61px)]">
+          <div className="flex-1  h-full overflow-auto">
+            <div className="grid grid-cols-[repeat(4,max-content)_1fr] grid-flow-col auto-cols-min bg-slate-900">
+              <Row className="hover:cursor-auto">
+                <Column className="bg-slate-950/50 font-bold">Time</Column>
+                <Column className="bg-slate-950/50 font-bold">Method</Column>
+                <Column className="bg-slate-950/50 font-bold justify-end">
+                  Size
+                </Column>
+                <Column className="bg-slate-950/50 font-bold justify-end">
+                  Ago
+                </Column>
+                <Column className="bg-slate-950/50">
+                  <span className="sr-only">Actions</span>
+                </Column>
+              </Row>
               {requests.data
                 .sort((a, b) => {
                   return (
@@ -180,45 +174,57 @@ const Bin = () => {
                     Number(new Date(a.timestamp))
                   );
                 })
-                .map((request, i) => {
-                  const isActive = currentRequestId === request.id;
-                  return (
-                    <li
-                      key={request.id}
-                      onClick={() => {
-                        getRequestData(request.id);
-                      }}
-                      className={`flex justify-between hover:cursor-pointer px-2 py-1 border-gray-700 transition-all ${
-                        isActive
-                          ? "bg-[#FF00BD] text-white"
-                          : "hover:text-[#FF00BD]"
-                      } ${i === requests.data.length - 1 ? "rounded-b-md" : ""}
-                      ${i === 0 ? "rounded-t-md" : ""}
-                      `}
-                    >
-                      <div className="font-mono w-full justify-between sm:flex">
-                        <span className="font-bold">
-                          {request.method.toUpperCase()}
-                        </span>{" "}
-                        <span className="opacity-80">
-                          {timeAgo(Number(new Date(request.timestamp)))}
-                        </span>
-                      </div>
-                    </li>
-                  );
-                })}
-              {requests.data.length === 0 ? "No requests yet" : null}
-            </ul>
+                .map((request) => (
+                  <Row
+                    key={request.id}
+                    onClick={() => {
+                      getRequestData(request.id);
+                    }}
+                    className={cn(
+                      "relative",
+                      currentRequestId === request.id &&
+                        "after:rounded after:shadow-[inset_0_0_0_2px_#FF00BD] after:opacity-70 after:content-[''] after:absolute after:inset-0",
+                    )}
+                  >
+                    <Column>
+                      {new Date(request.timestamp).toLocaleString()}
+                    </Column>
+                    <Column>
+                      <MethodIndicator method={request.method} />
+                    </Column>
+                    <Column className="justify-end">
+                      {request.size} bytes
+                    </Column>
+                    <Column className="justify-end">
+                      {timeAgo(Number(new Date(request.timestamp)))}
+                    </Column>
+                    <Column className="flex justify-end items-center text-white">
+                      <button className="group-hover:bg-slate-700 p-1 rounded">
+                        <ArrowIcon />
+                      </button>
+                    </Column>
+                  </Row>
+                ))}
+            </div>
           </div>
-          <div className="col-span-7">
-            <BinRequest
-              isLoading={isLoading || isRefreshing}
-              requestDetails={currentRequest}
-            />
-          </div>
+          {currentRequestId && (
+            <>
+              <div className="fixed top-0 right-0 bottom-0 left-1/2 w-[1px] border-l border-slate-800" />
+              <aside className="flex-1 w-1/2 h-full overflow-auto">
+                <BinRequest
+                  isLoading={isLoading || isRefreshing}
+                  requestDetails={currentRequest}
+                  onClose={() => {
+                    setCurrentRequest(undefined);
+                    setCurrentRequestId(undefined);
+                  }}
+                />
+              </aside>
+            </>
+          )}
         </div>
       )}
-    </Frame>
+    </main>
   );
 };
 

--- a/www/styles/globals.css
+++ b/www/styles/globals.css
@@ -4,6 +4,7 @@
 
 :root {
   background: #000019;
+  color: #fff;
 }
 
 .loading-background {


### PR DESCRIPTION
Heya! 

This PR is a bit bigger because I've reworked the request list page quite a bit, and these changes are mostly related.

I’ve given it a bit of a dashboard-y look and feel with full width/height, similar to other dev tools.
I took some liberties in coloring and how the layout works.

I hope you like the changes and I’d love to get some feedback 🚀

Here's a short demo showing a new bin with no requests and a bin with some requests already fired:

https://github.com/zuplo/mockbin/assets/571589/e41cd90e-3ec3-4569-a13e-4aa707e6257b

Some notes:
- Needed to upgrade `tailwind` to the latest version to be able to use subgrids (essentially working as a table row)
- Added some more icons to spice it up (taken from [lucide.dev](https://lucide.dev/))
- 💡 Idea: The path of a request that was sent to a bin could be stored in S3 as well (as metadata?) so it could be listed in the overview already
