### PR TITLE
feat: Make columns resizable

### DIFF
--- a/www/components/BinRequest.tsx
+++ b/www/components/BinRequest.tsx
@@ -1,6 +1,6 @@
 import CopyButton from "@/components/CopyButton";
 import Tabs, { Tab } from "@/components/Tabs";
-import React, { useEffect, useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 import { RequestDetails } from "../utils/interfaces";
 import { getMethodTextColor } from "@/components/MethodIndicator";
 import CloseIcon from "@/components/CloseIcon";
@@ -63,7 +63,8 @@ const BinRequest = ({
     requestIsJson ? "JSON" : "RAW",
   );
 
-  useEffect(() => {
+  // useLayoutEffect is used here to prevent flickering of the wrong tab being selected
+  useLayoutEffect(() => {
     setSelectedTab(requestIsJson ? "JSON" : "RAW");
   }, [requestIsJson]);
 

--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -13,6 +13,7 @@ import useInterval from "@/hooks/useInterval";
 import MethodIndicator from "@/components/MethodIndicator";
 import BinHeader from "@/components/BinHeader";
 import ArrowIcon from "@/components/ArrowIcon";
+import { useBinColumnsResize } from "@/utils/useBinColumnsResize";
 
 const POLL_INTERVAL = 5000;
 
@@ -113,6 +114,10 @@ const Bin = () => {
     setIsLoading(false);
   };
 
+  const { handleDividerMouseDown, leftColumnPercentage } = useBinColumnsResize(
+    Boolean(currentRequestId),
+  );
+
   if (easterEggActive) {
     return (
       <Frame>
@@ -167,10 +172,12 @@ const Bin = () => {
         </div>
       ) : (
         <div
-          className={cn(
-            "grid border-t border-slate-800 text-sm h-[calc(100vh-60px)]",
-            currentRequestId ? "grid-cols-[1fr,8px,1fr]" : "grid-cols-[1fr]",
-          )}
+          className="grid border-t border-slate-800 text-sm h-[calc(100vh-60px)]"
+          style={{
+            gridTemplateColumns: currentRequestId
+              ? `minmax(600px, ${leftColumnPercentage}%) 8px minmax(350px, 1fr)`
+              : "1fr",
+          }}
         >
           <div className="h-full overflow-auto">
             <div className="grid grid-cols-[repeat(4,max-content)_1fr] grid-flow-col auto-cols-min bg-slate-900">
@@ -229,7 +236,10 @@ const Bin = () => {
           </div>
           {currentRequestId && (
             <>
-              <div className="border-l border-slate-800" />
+              <div
+                className="border-l border-slate-800 cursor-col-resize"
+                onMouseDown={handleDividerMouseDown}
+              />
               <aside className="h-full overflow-auto">
                 <BinRequest
                   isLoading={isLoading || isRefreshing}

--- a/www/utils/useBinColumnsResize.ts
+++ b/www/utils/useBinColumnsResize.ts
@@ -1,0 +1,56 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "@mockbin/left-column";
+
+export const useBinColumnsResize = (isOpen: boolean) => {
+  const [leftColumnPercentage, setLeftColumnPercentage] = useState(() =>
+    typeof window === "undefined"
+      ? 50
+      : Number(localStorage.getItem(STORAGE_KEY) ?? 50),
+  );
+  // Used in mouseUp event handler to store the latest value of leftColumnPercentage in localStorage
+  const leftPercentageRef = useRef(leftColumnPercentage);
+
+  useEffect(() => {
+    setLeftColumnPercentage(
+      isOpen ? Number(localStorage.getItem(STORAGE_KEY) ?? 50) : 0,
+    );
+  }, [isOpen]);
+
+  const handleDividerMouseDown = useCallback((event: React.MouseEvent) => {
+    const { parentElement } = event.currentTarget;
+    const width = parentElement?.offsetWidth ?? 0;
+
+    // firstElementChild should be good enough to get the left column (another option would be to use a ref)
+    const leftColumn = parentElement?.firstElementChild as HTMLElement;
+
+    leftColumn.style.pointerEvents = "none";
+    // Prevent selecting page content while resizing
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    const onMouseMove = (mouseMoveEvent: MouseEvent) => {
+      const newWidth = (mouseMoveEvent.clientX / width) * 100;
+      const clampedWidth = Math.min(Math.max(newWidth, 0), 100);
+
+      setLeftColumnPercentage(clampedWidth);
+      leftPercentageRef.current = clampedWidth;
+    };
+
+    const onMouseUp = () => {
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      leftColumn.style.pointerEvents = "";
+
+      localStorage.setItem(STORAGE_KEY, String(leftPercentageRef.current));
+
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, []);
+
+  return { leftColumnPercentage, handleDividerMouseDown } as const;
+};


### PR DESCRIPTION
I've added the ability to make the columns resizable. The value is stored in `localStorage` to provide a consistent experience.

_Note:_ I've also fixed a small issue here, where the wrong tab was flashing for a split second. This was because `useEffect` fired after the first render, this is resolved by using `useLayoutEffect`.

Demo:

https://github.com/zuplo/mockbin/assets/571589/f9f155ae-bdd2-4882-a20b-13c7aad35ed6