### PR TITLE
feat: Index page revamp

### DIFF
--- a/www/components/BinHeader.tsx
+++ b/www/components/BinHeader.tsx
@@ -5,6 +5,7 @@ import CopyButton from "@/components/CopyButton";
 import RefreshIcon from "@/components/RefreshIcon";
 import ArrowIcon from "@/components/ArrowIcon";
 import cn from "classnames";
+import Button from "@/components/Button";
 
 const BinHeader = ({
   binUrl,
@@ -33,17 +34,9 @@ const BinHeader = ({
       <CopyButton textToCopy={binUrl} />
     </div>
     <div className="flex gap-4 px-4 items-center">
-      <Link
-        tabIndex={0}
-        href="/"
-        className={cn(
-          "relative rounded-md px-4 py-1 text-sm font-medium bg-gradient-to-b from-[#FF00BD] to-[#C0008F] opacity-85 transition-transform",
-          "hover:opacity-100 hover:scale-105",
-          "focus:ring-4 focus:outline-none focus:ring-[#C0008F]/50",
-        )}
-      >
+      <Button as="a" tabIndex={0} href="/">
         Create Bin
-      </Link>
+      </Button>
       <button
         className="px-2 py-2 hover:bg-slate-800 rounded"
         onClick={onRefresh}

--- a/www/components/Button.tsx
+++ b/www/components/Button.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import cn from "classnames";
+
+export type MergeWithAs<
+  Comp extends React.ElementType,
+  Props extends {} = {},
+> = Omit<Props, "as"> & { as?: Comp };
+
+export type ComponentPropsWithAs<
+  Comp extends React.ElementType,
+  Props extends {} = {},
+> = Omit<React.ComponentPropsWithoutRef<Comp>, keyof MergeWithAs<Comp, Props>> &
+  MergeWithAs<Comp, Props>;
+
+const Button = <T extends React.ElementType = "button">({
+  as,
+  className,
+  ...props
+}: ComponentPropsWithAs<T>) => {
+  const Component = as ?? "button";
+
+  return (
+    <Component
+      className={cn(
+        "relative rounded-md px-4 py-1 text-sm font-medium bg-gradient-to-b from-[#FF00BD] to-[#C0008F] transition-transform",
+        "hover:scale-105",
+        "focus:ring-4 focus:outline-none focus:ring-[#C0008F]/50",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export default Button;

--- a/www/components/Frame.tsx
+++ b/www/components/Frame.tsx
@@ -3,14 +3,18 @@ import Header from "./Header";
 
 export default function Frame({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-col bg-[#000019] items-center h-screen">
-      <div className="w-full h-full max-w-5xl px-4 flex flex-col text-white">
+    <div className="flex flex-col items-center h-screen">
+      <div className="w-full h-full max-w-6xl px-4 flex flex-col text-white">
         <div className="flex-none">
           <Header />
         </div>
         <div className="flex-grow">{children}</div>
-        <div className="flex flex-row py-3 w-full justify-between mt-4">
-          <a target="_blank" href="https://zuplo.com/?c=mbf" className="text-xl">
+        <div className="flex flex-row py-3 w-full justify-between sm:justify-center">
+          <a
+            target="_blank"
+            href="https://zuplo.com/?c=mbf"
+            className="text-md font-bold text-slate-300"
+          >
             Made with ❤️ by{" "}
             <span className="underline font-bold text-[#FF00BD]">Zuplo</span>
           </a>

--- a/www/components/Header.tsx
+++ b/www/components/Header.tsx
@@ -1,15 +1,12 @@
 import Image from "next/image";
 import Link from "next/link";
+import HeaderImage from "../public/mockbin-header.png";
+
 const Header = () => {
   return (
     <header className="flex flex-row w-full justify-between items-center">
       <Link href="/">
-        <Image
-          width={360}
-          height={132}
-          alt="mockbin logo"
-          src="/mockbin-header.png"
-        />
+        <Image width={360} height={132} alt="mockbin logo" src={HeaderImage} />
       </Link>
       <div className="flex gap-x-2 items-center">
         <a
@@ -40,7 +37,7 @@ const Header = () => {
           src="https://ghbtns.com/github-btn.html?user=zuplo&repo=mockbin&type=star&count=true&size=large"
           frameBorder="0"
           scrolling="0"
-          width="120"
+          width="75"
           height="30"
           title="GitHub"
         ></iframe>

--- a/www/components/HeaderRow.tsx
+++ b/www/components/HeaderRow.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { Header } from "./HeadersList";
+import Input from "@/components/Input";
+import TrashIcon from "@/components/TrashIcon";
 
 interface HeaderRowProps {
   header: Header;
@@ -8,23 +10,6 @@ interface HeaderRowProps {
   onChange: (header: Header) => void;
   onDelete?: (id: string) => void;
 }
-
-const TrashIcon = ({ className }: { className: string }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth="1.5"
-    stroke="currentColor"
-    className="w-6 h-6"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 9.75L14.25 12m0 0l2.25 2.25M14.25 12l2.25-2.25M14.25 12L12 14.25m-2.58 4.92l-6.375-6.375a1.125 1.125 0 010-1.59L9.42 4.83c.211-.211.498-.33.796-.33H19.5a2.25 2.25 0 012.25 2.25v10.5a2.25 2.25 0 01-2.25 2.25h-9.284c-.298 0-.585-.119-.796-.33z"
-    />
-  </svg>
-);
 
 const HeaderRow = ({
   header,
@@ -91,12 +76,11 @@ const HeaderRow = ({
   };
 
   return (
-    <div className="flex align-top items-start flex-wrap sm:flex-nowrap">
+    <div className="flex align-top items-start gap-2 flex-wrap sm:flex-nowrap">
       <div className="w-full flex flex-col">
-        <input
+        <Input
           value={header.key}
           placeholder="Key"
-          className="text-white bg-[#000019] border font-mono p-1 px-2 border-gray-300 rounded-md"
           title={"Header key"}
           onChange={onChangeKey}
         />
@@ -104,10 +88,9 @@ const HeaderRow = ({
           <p className="mt-2 text-sm text-red-600">&nbsp;{keyError}</p>
         ) : null}
       </div>
-      <div className="w-full flex flex-col sm:pl-3 sm:pr-2 mt-4 sm:mt-0">
-        <input
+      <div className="w-full flex flex-col mt-4 sm:mt-0">
+        <Input
           value={header.value}
-          className="text-white bg-[#000019] border font-mono p-1 px-2 border-gray-300 rounded-md"
           onChange={onChangeValue}
           placeholder="Value"
         />
@@ -116,12 +99,12 @@ const HeaderRow = ({
         ) : null}
       </div>
       <button
-        className="p-1 my-1 px-1 -mr-2 enabled:hover:bg-gray-400 dark:enabled:hover:bg-gray-400 rounded transition-all disabled:cursor-not-allowed disabled:opacity-50 enabled:hover:text-black"
+        className="p-1 translate-y-[2px] enabled:hover:bg-gray-400 dark:enabled:hover:bg-slate-800 rounded transition-all disabled:cursor-not-allowed disabled:opacity-50"
+        type="button"
         onClick={onClickDelete}
         disabled={!canBeDeleted}
-        title="Delete header"
       >
-        <TrashIcon className="h-5 w-5" />
+        <TrashIcon />
       </button>
     </div>
   );

--- a/www/components/HeadersList.tsx
+++ b/www/components/HeadersList.tsx
@@ -42,7 +42,7 @@ const HeadersList = ({ headers, onChange }: HeaderListProps) => {
   };
 
   return (
-    <div className="flex flex-col gap-y-4 w-full">
+    <div className="flex flex-col gap-y-2 w-full">
       {headers.map((header, index) => (
         <HeaderRow
           header={header}

--- a/www/components/InfoIcon.tsx
+++ b/www/components/InfoIcon.tsx
@@ -1,0 +1,20 @@
+const InfoIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="lucide lucide-info"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 16v-4" />
+    <path d="M12 8h.01" />
+  </svg>
+);
+
+export default InfoIcon;

--- a/www/components/Input.tsx
+++ b/www/components/Input.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import cn from "classnames";
+
+const Input = ({
+  value,
+  onChange,
+  className,
+  textarea,
+  ...props
+}: { textarea?: boolean } & React.InputHTMLAttributes<
+  HTMLInputElement | HTMLTextAreaElement
+>) => {
+  const Comp = textarea ? "textarea" : "input";
+  return (
+    <Comp
+      value={value}
+      onChange={onChange}
+      className={cn(
+        "bg-transparent border font-mono p-1 px-2 border-slate-700 flex-grow rounded",
+        "focus:ring-4 focus:outline-none focus:ring-slate-700/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export default Input;

--- a/www/components/TrashIcon.tsx
+++ b/www/components/TrashIcon.tsx
@@ -1,0 +1,20 @@
+const TrashIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="lucide lucide-x-circle"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="m15 9-6 6" />
+    <path d="m9 9 6 6" />
+  </svg>
+);
+
+export default TrashIcon;

--- a/www/pages/_document.tsx
+++ b/www/pages/_document.tsx
@@ -32,6 +32,11 @@ export default function Document() {
           property="og:image"
           content="https://cdn.zuplo.com/assets/8e93df64-1a75-4cfe-afb7-10a99def9e0c.png"
         />
+        <link
+          href="https://fonts.googleapis.com/css?family=Fira+Code"
+          rel="stylesheet"
+          type="text/css"
+        />
         {process.env.NEXT_PUBLIC_ANALYTICS_URL ? (
           // eslint-disable-next-line @next/next/no-sync-scripts
           <script src={process.env.NEXT_PUBLIC_ANALYTICS_URL}></script>

--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -127,7 +127,7 @@ const Bin = () => {
           </h1>
           <h2 className="text-3xl mb-8 text-center">
             But you can{" "}
-            <Link className="text-[#FF00BD] hover:text-[#C0008F]" href="/">
+            <Link className="text-zuplo-primary hover:text-[#C0008F]" href="/">
               create a new bin
             </Link>{" "}
             in seconds
@@ -153,7 +153,7 @@ const Bin = () => {
           No requests made to your Bin yet. Send a request to see it here.
           <div className="flex flex-col gap-2">
             <code className="text-md bg-slate-800 rounded border border-slate-700 p-4 py-2 flex items-center gap-2">
-              <span className="text-[#FF00BD]">{binUrl}</span>
+              <span className="text-zuplo-primary">{binUrl}</span>
               <div className="translate-x-1 translate-y-0.5">
                 <CopyButton textToCopy={binUrl} />
               </div>
@@ -210,7 +210,7 @@ const Bin = () => {
                     className={cn(
                       "relative",
                       currentRequestId === request.id &&
-                        "after:rounded after:shadow-[inset_0_0_0_2px_#FF00BD] after:opacity-70 after:content-[''] after:absolute after:inset-0",
+                        "after:rounded after:shadow-[inset_0_0_0_2px_theme(colors.zuplo.primary)] after:opacity-70 after:content-[''] after:absolute after:inset-0",
                     )}
                   >
                     <Column>

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -231,8 +231,8 @@ const Index = () => {
               ))}
             </ul>
           ) : (
-            <p className="text-gray-300">
-              You haven’t created any bins yet. Create one above to get started.
+            <p className="text-gray-300 px-4 py-2 text-sm italic">
+              No bins yet. All recent ones will show up here
             </p>
           )}
         </div>

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -1,10 +1,14 @@
 import Frame from "@/components/Frame";
-import { getURL, timeAgo } from "@/utils/helpers";
+import { timeAgo } from "@/utils/helpers";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { v4 } from "uuid";
 import HeadersList, { Header } from "../components/HeadersList";
+import cn from "classnames";
+import Button from "@/components/Button";
+import Input from "@/components/Input";
+import InfoIcon from "@/components/InfoIcon";
 
 const RECENT_BIN_KEY = "LAST_BINS";
 type RecentBin = {
@@ -12,6 +16,15 @@ type RecentBin = {
   createdTime: string;
   url: string;
 };
+
+// prettier-ignore
+const STATUS_CODE_MAP = {
+  200: "OK", 201: "Created", 202: "Accepted", 204: "No Content", 300: "Multiple Choices",
+  301: "Moved Permanently", 302: "Found", 304: "Not Modified", 400: "Bad Request",
+  401: "Unauthorized", 403: "Forbidden", 404: "Not Found", 405: "Method Not Allowed",
+  418: "I'm a teapot", 429: "Too Many Requests", 500: "Internal Server Error",
+  502: "Bad Gateway", 503: "Service Unavailable", 504: "Gateway Timeout",
+} as const;
 
 const Index = () => {
   const [status, setStatus] = useState("200");
@@ -30,7 +43,9 @@ const Index = () => {
       id: v4(),
     },
   ]);
-  const [responseBody, setResponseBody] = useState("{}");
+  const [responseBody, setResponseBody] = useState(
+    `{\n  "message": "Hello World"\n}`,
+  );
   const [recentBins, setRecentBins] = useState<RecentBin[]>([]);
   const [isCreating, setIsCreating] = useState(false);
   const router = useRouter();
@@ -44,6 +59,13 @@ const Index = () => {
     const recentBins: RecentBin[] = binsRaw ? JSON.parse(binsRaw) : [];
     setRecentBins(recentBins);
   }, []);
+
+  useEffect(() => {
+    const intStatus = Number(status);
+    if (!(intStatus in STATUS_CODE_MAP)) return;
+
+    setStatusText(STATUS_CODE_MAP[intStatus as keyof typeof STATUS_CODE_MAP]);
+  }, [status]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -84,11 +106,11 @@ const Index = () => {
       setIsCreating(false);
       router.push(`/bins/${result.id}`);
       const createdTime = new Date().toISOString();
-      const recentBinEntry: RecentBin = {
+      const recentBinEntry = {
         id: result.id,
         createdTime,
         url: result.url,
-      };
+      } satisfies RecentBin;
       const newRecentBins = [recentBinEntry, ...recentBins];
       if (typeof window !== "undefined") {
         localStorage.setItem(RECENT_BIN_KEY, JSON.stringify(newRecentBins));
@@ -102,95 +124,119 @@ const Index = () => {
 
   return (
     <Frame>
-      <div className="my-10">
+      <div className="my-8 flex flex-col gap-4">
         <h1 className="text-3xl">
           Welcome to <span className="font-bold">Mockbin by Zuplo</span>
         </h1>
-        <p className="text-gray-300 ">
+        <p className="text-gray-300">
           This is an open-source and fully-free tool that allows you to quickly
           mock an API endpoint, configure a fixed response and track requests to
           your endpoint.
         </p>
       </div>
-      <div className="my-10">
-        {recentBins.length > 0 ? (
-          <ul className="flex flex-col ">
-            <h2 className="text-xl font-bold">Your recent bins</h2>
-            <div className="flex flex-col gap-y-2 list-disc list-inside">
-              {recentBins.slice(0, 5).map((bin) => {
-                return (
-                  <li key={bin.id}>
-                    <Link
-                      href={`/bins/${bin.id}`}
-                      className="text-[#FF00BD] hover:text-[#FF90E3] hover:bg-pink-500 hover:bg-opacity-50 rounded p-1 -ml-1 font-mono mr-4 break-all transition-all"
-                    >{`${bin.id}`}</Link>
-                    <span className="font-mono opacity-70">
-                      {timeAgo(Number(new Date(bin.createdTime)))}
-                    </span>
-                  </li>
-                );
-              })}
-            </div>
-            <p className="mt-4 text-sm w-fit border border-gray-700 p-2 rounded-md opacity-70">
-              Mockbin is free of sign-ups. These bin IDs are stored in your
-              browser storage.{" "}
-            </p>
-          </ul>
-        ) : null}
-      </div>
-      <form
-        className="gap-y-2 px-4 py-4 border border-dashed border-gray-700 shadow-xl shadow-[#FF00BD]/10 rounded-md"
-        onSubmit={handleSubmit}
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "start",
-        }}
+      <div
+        className={cn(
+          "flex border border-gray-700 rounded relative",
+          "flex-col lg:flex-row",
+        )}
       >
-        <h2 className="text-3xl font-bold">Create a new bin</h2>
-        <p>
-          Just specify the details of the response below and we’ll create you a
-          new API endpoint in a jiffy.
-        </p>
-        <div className="mt-8 w-full flex flex-col gap-y-2 sm:grid sm:grid-cols-5 sm:gap-y-4">
-          <label className="mt-1 font-bold">Status</label>
-          <input
-            type="text"
-            placeholder="Status Code"
-            value={status}
-            onChange={(e) => setStatus(e.target.value)}
-            className="text-white bg-[#000019] border col-span-2 font-mono p-1 px-2 sm:mr-4 border-gray-300 flex-grow rounded-md"
-          />
-          <div className="col-span-2"></div>
-          <label className="mt-1 font-bold">Status Text</label>
-          <input
-            type="text"
-            placeholder="Status Text"
-            value={statusText}
-            onChange={(e) => setStatusText(e.target.value)}
-            className="text-white bg-[#000019] border col-span-2 font-mono p-1 px-2 sm:mr-4 border-gray-300 flex-grow rounded-md"
-          />
-          <div className="col-span-2"></div>
-          <label className="mt-1 font-bold">Headers</label>
-          <div className="col-span-4">
-            <HeadersList headers={headers} onChange={setHeaders} />
-          </div>
-          <label className="mt-1 font-bold">Body</label>
-          <textarea
-            placeholder="{}"
-            className="text-white bg-[#000019] border font-mono p-1 px-2 mt-1 border-gray-300 h-32 w-full col-span-4 rounded-md"
-            value={responseBody}
-            onChange={(e) => setResponseBody(e.target.value)}
-          />
-        </div>
-        <button
-          className="self-end bg-[#FF00BD] rounded-md p-2 mt-3 px-4 font-bold enabled:hover:bg-[#C0008F] disabled:opacity-50"
-          disabled={isCreating}
-          type="submit"
+        <form
+          className={cn(
+            "py-4 px-6 text-sm flex flex-col gap-6 items-start rounded-r-none",
+            "lg:w-[60%]",
+          )}
+          onSubmit={handleSubmit}
         >
-          {isCreating ? "Creating" : "Create Bin"}
-        </button>
-      </form>
+          <h2 className="text-3xl font-bold w-full">Create a new Bin</h2>
+          <p>
+            Just specify the details of the response below and we’ll create you
+            a new API endpoint in a jiffy.
+          </p>
+          <div className="w-full gap-2 grid grid-cols-[75px_repeat(2,140px)_1fr]">
+            <label className="mt-1 font-bold">Status</label>
+            <Input
+              type="text"
+              placeholder="Status Code"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            />
+            <Input
+              type="text"
+              placeholder="Status Text"
+              value={statusText}
+              onChange={(e) => setStatusText(e.target.value)}
+              className="col-span-2"
+            />
+            <label className="mt-1 font-bold">Headers</label>
+            <div className="col-span-3">
+              <HeadersList headers={headers} onChange={setHeaders} />
+            </div>
+            <label className="mt-1 font-bold">Body</label>
+            <Input
+              textarea
+              placeholder="{}"
+              value={responseBody}
+              className="w-full col-span-3 h-32"
+              onChange={(e) => setResponseBody(e.target.value)}
+            />
+          </div>
+          <div className="self-end">
+            <Button disabled={isCreating} type="submit">
+              {isCreating ? "Creating" : "Create Bin"}
+            </Button>
+          </div>
+          <div className="col-span-4">
+            <span className="flex items-center gap-2 text-xs text-slate-500">
+              <InfoIcon />
+              Mockbin is free of sign-ups. The bin IDs are only stored in your
+              browser storage.
+            </span>
+          </div>
+        </form>
+        <div
+          className={cn(
+            "bg-slate-800/80 inset-0 overflow-y-auto max-h-[300px] border-gray-700 border-t",
+            "lg:absolute lg:min-h-full lg:max-h-fit lg:w-[40%] lg:left-auto lg:border-t-0 lg:border-l",
+          )}
+        >
+          <h2 className="text-xl font-bold mb-2 border-b border-slate-700 py-3 px-4">
+            Your recent bins
+          </h2>
+          {recentBins.length > 0 ? (
+            <ul className="list-none flex flex-col gap-1 text-sm p-4">
+              {recentBins.map((bin) => (
+                <li
+                  key={bin.id}
+                  className={cn(
+                    "group relative inline-flex gap-6 items-center justify-between",
+                    "before:content-['→'] before:text-xs before:-translate-y-[1px] before:absolute",
+                  )}
+                >
+                  <Link
+                    href={`/bins/${bin.id}`}
+                    className={cn(
+                      "ps-7 truncate text-zuplo-primary font-mono rounded px-2 py-1 -mx-2 -my-1 transition-all",
+                      "hover:text-zuplo-primary/90 hover:bg-zuplo-primary hover:bg-opacity-50",
+                    )}
+                  >
+                    {bin.id}
+                  </Link>
+                  <span
+                    className="text-end flex-shrink-0"
+                    title={new Date(bin.createdTime).toLocaleString()}
+                  >
+                    {timeAgo(Number(new Date(bin.createdTime)))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-gray-300">
+              You haven’t created any bins yet. Create one above to get started.
+            </p>
+          )}
+        </div>
+      </div>
     </Frame>
   );
 };

--- a/www/tailwind.config.ts
+++ b/www/tailwind.config.ts
@@ -8,6 +8,11 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        zuplo: {
+          primary: "#ff00bd",
+        },
+      },
       fontFamily: {
         mono: ["Fira Code", "monospace"],
       },

--- a/www/tailwind.config.ts
+++ b/www/tailwind.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        mono: ["Fira Code", "monospace"],
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":


### PR DESCRIPTION
Following up on the request list overview page, I also reworked the index page.
I didn't change it as drastically, but I cleaned up the font sizes a bit and rendered the list of recent bins next to the form to save some space.

I also added `Fira Code` as the mono font as the default one looked a bit bland.

<img src="https://github.com/zuplo/mockbin/assets/571589/a80cf530-9482-48e2-a2a0-ccd7012c0a7d">
