### PR TITLE
feat: Add copy state for "Copy cURL" example button

### DIFF
--- a/www/components/CopyButton.tsx
+++ b/www/components/CopyButton.tsx
@@ -1,5 +1,4 @@
-import useInterval from "@/hooks/useInterval";
-import { useState } from "react";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 type CopyButtonProps = {
   classNames?: string;
@@ -36,30 +35,14 @@ const CheckIcon = ({ className }: { className: string }) => (
   </svg>
 );
 
-const COPY_SUCCESS_TIMEOUT_MS = 2000;
-const CopyButton = ({ classNames, textToCopy }: CopyButtonProps) => {
-  const [hasCopied, setHasCopied] = useState(false);
-  useInterval(
-    () => {
-      setHasCopied(false);
-    },
-    hasCopied ? COPY_SUCCESS_TIMEOUT_MS : null,
-  );
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(textToCopy);
-    } catch (e) {
-      return;
-    }
-
-    setHasCopied(true);
-  };
+const CopyButton = ({ textToCopy }: CopyButtonProps) => {
+  const [hasCopied, copy] = useCopyToClipboard();
 
   return (
     <button
       type="button"
       className={`items-center rounded-md p-1 hover:bg-slate-800 transition-all`}
-      onClick={onCopy}
+      onClick={() => copy(textToCopy)}
     >
       {hasCopied ? (
         <CheckIcon className="h-4 w-4 text-green-500" />

--- a/www/hooks/useCopyToClipboard.ts
+++ b/www/hooks/useCopyToClipboard.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+
+export const useCopyToClipboard = (timeout = 2000) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), timeout);
+      } catch {
+        setCopied(false);
+      }
+    },
+    [timeout],
+  );
+
+  return [copied, copy] as const;
+};

--- a/www/pages/bins/[binId].tsx
+++ b/www/pages/bins/[binId].tsx
@@ -14,6 +14,7 @@ import MethodIndicator from "@/components/MethodIndicator";
 import BinHeader from "@/components/BinHeader";
 import ArrowIcon from "@/components/ArrowIcon";
 import { useBinColumnsResize } from "@/utils/useBinColumnsResize";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 const POLL_INTERVAL = 5000;
 
@@ -117,6 +118,7 @@ const Bin = () => {
   const { handleDividerMouseDown, leftColumnPercentage } = useBinColumnsResize(
     Boolean(currentRequestId),
   );
+  const [hasCopied, copy] = useCopyToClipboard();
 
   if (easterEggActive) {
     return (
@@ -159,14 +161,22 @@ const Bin = () => {
               </div>
             </code>
             <button
-              className="self-end bg-slate-700 px-3 py-1 rounded text-sm hover:bg-slate-800"
+              className="self-end bg-slate-700 px-3 py-1 rounded text-sm hover:bg-slate-800 relative"
               onClick={() =>
-                navigator.clipboard.writeText(
+                copy(
                   `curl -X POST -H "Content-Type: application/json" -d '{"message": "Hello World"}' ${binUrl}`,
                 )
               }
             >
-              Copy cURL
+              <span className={cn(hasCopied && "invisible")}>Copy cURL</span>
+              <span
+                className={cn(
+                  "absolute inset-0 grid place-items-center",
+                  !hasCopied && "invisible",
+                )}
+              >
+                Copied!
+              </span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
Simply added a state for when the button has been clicked. Moved logic into its own hook

https://github.com/zuplo/mockbin/assets/571589/a55202d8-16da-405a-b22e-1b4934268dd9

