### PR TITLE
Added OpenAPI support (dirty)

### DIFF
--- a/config/routes.oas.json
+++ b/config/routes.oas.json
@@ -34,7 +34,9 @@
                   "response": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["status"],
+                    "required": [
+                      "status"
+                    ],
                     "properties": {
                       "status": {
                         "type": "number"
@@ -65,10 +67,34 @@
             "options": {}
           },
           "policies": {
-            "inbound": ["request-validation-inbound", "rate-limit-inbound"]
+            "inbound": [
+              "request-validation-inbound",
+              "rate-limit-inbound"
+            ]
           }
         },
         "operationId": "2e21caf1-f4c5-4b8a-8358-b335b4fd4222"
+      }
+    },
+    "/v1/bins/openapi": {
+      "x-zuplo-path": {
+        "pathMode": "open-api"
+      },
+      "post": {
+        "summary": "Create OpenAPI bin",
+        "description": "Lorem ipsum dolor sit amet, **consectetur adipiscing** elit, sed do `eiusmod tempor` incididunt ut labore et dolore magna aliqua.",
+        "x-zuplo-route": {
+          "corsPolicy": "anything-goes",
+          "handler": {
+            "export": "createMockResponse",
+            "module": "$import(./modules/handlers)",
+            "options": {}
+          },
+          "policies": {
+            "inbound": []
+          }
+        },
+        "operationId": "6e4b7ac5-f1e4-48b4-82b5-336d48aaef24"
       }
     },
     "/v1/bins/{binId}": {
@@ -86,7 +112,10 @@
             "options": {}
           },
           "policies": {
-            "inbound": ["block-bad-bins", "rate-limit-inbound"]
+            "inbound": [
+              "block-bad-bins",
+              "rate-limit-inbound"
+            ]
           }
         },
         "operationId": "2ae802d2-c8e1-40ba-ac2e-f45a9b4eafab"
@@ -107,7 +136,10 @@
             "options": {}
           },
           "policies": {
-            "inbound": ["block-bad-bins", "rate-limit-inbound"]
+            "inbound": [
+              "block-bad-bins",
+              "rate-limit-inbound"
+            ]
           }
         },
         "responses": {
@@ -129,7 +161,7 @@
             }
           }
         },
-        "operationId": "460b0c3d-6267-4913-9e42-46f6882e2a42"
+        "operationId": "5fbfb141-50e3-4803-8553-084825e7ce81"
       }
     },
     "/v1/bins/{binId}/requests/{requestId}": {
@@ -147,7 +179,10 @@
             "options": {}
           },
           "policies": {
-            "inbound": ["block-bad-bins", "rate-limit-inbound"]
+            "inbound": [
+              "block-bad-bins",
+              "rate-limit-inbound"
+            ]
           }
         },
         "responses": {

--- a/modules/log-request.ts
+++ b/modules/log-request.ts
@@ -15,7 +15,7 @@ export default async function (request: ZuploRequest, context: ZuploContext) {
   const { binId, pathname } = urlInfo;
 
   if (!validateBinId(binId)) {
-    return HttpProblems.badRequest(request, context);
+    return HttpProblems.badRequest(request, context, { detail: "Invalid binId" });
   }
 
   const headers: Record<string, string> = {};

--- a/modules/mock-server.ts
+++ b/modules/mock-server.ts
@@ -1,0 +1,450 @@
+export class MockServer {
+	private openApiDoc: any;
+
+	constructor(openApiDoc: any) {
+		this.openApiDoc = openApiDoc;
+	}
+
+	async handleRequest(request: Request): Promise<Response> {
+		try {
+			// Match request to operation in OpenAPI
+			const operationInfo = this.matchOperation(request);
+
+			if (!operationInfo) {
+				return this.problemDetailsResponse(404, 'Not Found', `No matching operation for ${request.method} ${request.url}`);
+			}
+
+			// Validate required parameters and their types
+			const paramValidationErrors = this.validateParameters(request, operationInfo);
+			if (paramValidationErrors.length > 0) {
+				return this.problemDetailsResponse(400, 'Bad Request', 'Invalid parameters', paramValidationErrors);
+			}
+
+			// Validate required request body
+			const bodyValidationErrors = await this.validateRequestBody(request, operationInfo);
+			if (bodyValidationErrors.length > 0) {
+				return this.problemDetailsResponse(400, 'Bad Request', 'Invalid request body', bodyValidationErrors);
+			}
+
+			// Generate response
+			const responseBody = this.generateResponse(operationInfo);
+
+			if (responseBody === null) {
+				return this.problemDetailsResponse(500, 'Internal Server Error', 'Unable to Mock. No mockable information found for this path.');
+			}
+
+			return new Response(JSON.stringify(responseBody), {
+				headers: { 'Content-Type': 'application/json' },
+			});
+		} catch (error: any) {
+			return this.problemDetailsResponse(500, 'Internal Server Error', error.message);
+		}
+	}
+
+	// Rest of the methods (matchOperation, validateParameters, etc.) remain the same,
+	// but are now methods of the MockServer class.
+
+	private matchOperation(request: Request): any {
+		const url = new URL(request.url);
+		const requestPath = url.pathname;
+		const requestMethod = request.method.toLowerCase();
+
+		for (const [pathPattern, pathItem] of Object.entries(this.openApiDoc.paths)) {
+			const pathRegex = this.pathPatternToRegex(pathPattern);
+			const match = requestPath.match(pathRegex);
+
+			if (match) {
+				const operation = pathItem[requestMethod];
+				if (operation) {
+					const pathParams = this.extractPathParams(pathPattern, requestPath);
+					return {
+						operation,
+						pathParams,
+					};
+				}
+			}
+		}
+		return null;
+	}
+
+	private pathPatternToRegex(pathPattern: string): RegExp {
+		const escapedPattern = pathPattern.replace(/([.+?^=!:${}()|\[\]/\\])/g, '\\$1');
+		const regexPattern = '^' + escapedPattern.replace(/\\\{([^}]+)\\\}/g, '([^/]+)') + '$';
+		return new RegExp(regexPattern);
+	}
+
+	private extractPathParams(
+		pathPattern: string,
+		requestPath: string
+	): {
+		[key: string]: string;
+	} {
+		const patternParts = pathPattern.split('/');
+		const pathParts = requestPath.split('/');
+		const params: { [key: string]: string } = {};
+
+		for (let i = 0; i < patternParts.length; i++) {
+			const patternPart = patternParts[i];
+			const pathPart = pathParts[i];
+			if (patternPart.startsWith('{') && patternPart.endsWith('}')) {
+				const paramName = patternPart.slice(1, -1);
+				params[paramName] = decodeURIComponent(pathPart);
+			}
+		}
+		return params;
+	}
+
+	private validateParameters(request: Request, operationInfo: any): string[] {
+		const { operation, pathParams } = operationInfo;
+		const errors: string[] = [];
+
+		if (operation.parameters) {
+			for (const param of operation.parameters) {
+				const resolvedParam = this.resolveRef(param);
+				const mergedParam = { ...resolvedParam, ...param }; // Merge properties
+
+				const paramName = mergedParam.name;
+				const paramIn = mergedParam.in;
+				const required = mergedParam.required || false;
+				const schema = this.resolveRef(mergedParam.schema);
+
+				let paramValue: any = null;
+
+				switch (paramIn) {
+					case 'query':
+						const url = new URL(request.url);
+						paramValue = url.searchParams.get(paramName);
+						break;
+					case 'header':
+						paramValue = request.headers.get(paramName);
+						break;
+					case 'path':
+						paramValue = pathParams[paramName];
+						break;
+					case 'cookie':
+						// Cookie parameters are not implemented in this example
+						break;
+					default:
+						break;
+				}
+
+				if (paramValue == null) {
+					if (required) {
+						errors.push(`Missing required ${paramIn} parameter '${paramName}'`);
+					}
+					continue; // Skip further validation if parameter is missing
+				}
+
+				// Convert parameter value to appropriate type for validation
+				paramValue = this.convertParameterValue(paramValue, schema.type);
+
+				// Validate type and enum
+				const validationErrors = this.validateSchema(paramValue, schema, paramName, true);
+				errors.push(...validationErrors);
+			}
+		}
+
+		return errors;
+	}
+
+	private convertParameterValue(value: string, type: string): any {
+		switch (type) {
+			case 'integer':
+				return parseInt(value, 10);
+			case 'number':
+				return parseFloat(value);
+			case 'boolean':
+				return value === 'true' || value === '1';
+			case 'array':
+				return value.split(',');
+			default:
+				return value;
+		}
+	}
+
+	private async validateRequestBody(request: Request, operationInfo: any): Promise<string[]> {
+		const { operation } = operationInfo;
+		const errors: string[] = [];
+
+		if (operation.requestBody && operation.requestBody.required) {
+			const contentType = request.headers.get('Content-Type') || '';
+			if (!contentType.includes('application/json')) {
+				errors.push('Invalid or missing Content-Type header');
+				return errors;
+			}
+
+			let requestBodyText: string;
+			try {
+				requestBodyText = await request.text();
+			} catch (e) {
+				errors.push('Unable to read request body');
+				return errors;
+			}
+
+			if (!requestBodyText) {
+				errors.push('Missing request body');
+				return errors;
+			}
+
+			let requestBodyJson: any;
+			try {
+				requestBodyJson = JSON.parse(requestBodyText);
+			} catch (e) {
+				errors.push('Invalid JSON in request body');
+				return errors;
+			}
+
+			// Get the schema from the OpenAPI document
+			const mediaType = operation.requestBody.content['application/json'];
+			if (!mediaType || !mediaType.schema) {
+				// No schema to validate against
+				return errors;
+			}
+
+			let schema = this.resolveRef(mediaType.schema);
+
+			// Validate the request body against the schema
+			const validationErrors = this.validateSchema(requestBodyJson, schema);
+			errors.push(...validationErrors);
+		}
+
+		return errors;
+	}
+
+	private resolveRef(obj: any): any {
+		if (!obj || !obj.$ref) {
+			return obj;
+		}
+
+		const refPath = obj.$ref;
+		const parts = refPath.replace(/^#\//, '').split('/'); // Remove initial '#/' and split
+		let refObj = this.openApiDoc;
+
+		for (const part of parts) {
+			if (refObj[part] !== undefined) {
+				refObj = refObj[part];
+			} else {
+				throw new Error(`Cannot resolve reference: ${refPath}`);
+			}
+		}
+
+		if (refObj.$ref) {
+			// Recursively resolve nested $ref
+			return this.resolveRef(refObj);
+		} else {
+			return refObj;
+		}
+	}
+
+	private validateSchema(data: any, schema: any, path: string = '', isParameter: boolean = false): string[] {
+		const errors: string[] = [];
+
+		schema = this.resolveRef(schema);
+
+		if (schema.type) {
+			if (!this.validateType(data, schema.type)) {
+				errors.push(`Expected type '${schema.type}' at path '${path}', but got '${typeof data}'`);
+				return errors;
+			}
+		}
+
+		if (schema.enum) {
+			if (!schema.enum.includes(data)) {
+				errors.push(`Value '${data}' at path '${path}' is not in enum [${schema.enum.join(', ')}]`);
+			}
+		}
+
+		if (schema.type === 'object') {
+			if (schema.required && Array.isArray(schema.required)) {
+				for (const propName of schema.required) {
+					if (data[propName] === undefined) {
+						errors.push(`Missing required field '${path ? path + '.' : ''}${propName}'`);
+					}
+				}
+			}
+
+			if (schema.properties) {
+				for (const [propName, propSchema] of Object.entries(schema.properties)) {
+					const resolvedPropSchema = this.resolveRef(propSchema);
+					const propPath = path ? `${path}.${propName}` : propName;
+					if (data[propName] !== undefined) {
+						errors.push(...this.validateSchema(data[propName], resolvedPropSchema, propPath));
+					}
+				}
+			}
+		} else if (schema.type === 'array') {
+			if (!Array.isArray(data)) {
+				errors.push(`Expected an array at path '${path}', but got '${typeof data}'`);
+			} else {
+				const itemSchema = this.resolveRef(schema.items);
+				for (let i = 0; i < data.length; i++) {
+					const itemPath = `${path}[${i}]`;
+					errors.push(...this.validateSchema(data[i], itemSchema, itemPath));
+				}
+			}
+		}
+
+		return errors;
+	}
+
+	private validateType(data: any, expectedType: string): boolean {
+		switch (expectedType) {
+			case 'string':
+				return typeof data === 'string';
+			case 'number':
+				return typeof data === 'number' && !isNaN(data);
+			case 'integer':
+				return Number.isInteger(data);
+			case 'boolean':
+				return typeof data === 'boolean';
+			case 'object':
+				return data !== null && typeof data === 'object' && !Array.isArray(data);
+			case 'array':
+				return Array.isArray(data);
+			case 'null':
+				return data === null;
+			default:
+				return false;
+		}
+	}
+
+	private generateResponse(operationInfo: any): any {
+		const { operation } = operationInfo;
+		const responses = operation.responses;
+
+		// Choose a response, prefer 200, else default
+		let response = responses['200'] || responses['default'];
+		if (!response) {
+			// Pick any response
+			response = Object.values(responses)[0];
+		}
+
+		if (!response) {
+			return null;
+		}
+
+		const content = response.content;
+		if (content) {
+			// Assume application/json
+			const mediaType = content['application/json'];
+			if (mediaType) {
+				if (mediaType.example) {
+					return mediaType.example;
+				}
+				if (mediaType.examples) {
+					// Pick first example
+					const example = Object.values(mediaType.examples)[0] as any;
+					if (example && example.value) {
+						return example.value;
+					}
+				}
+				if (mediaType.schema) {
+					const schema = this.resolveRef(mediaType.schema);
+					return this.generateExampleFromSchema(schema);
+				}
+			}
+		}
+		return null;
+	}
+
+	private generateExampleFromSchema(schema: any): any {
+		if (!schema) return null;
+
+		schema = this.resolveRef(schema);
+
+		if (schema.example !== undefined) {
+			return schema.example;
+		}
+
+		if (schema.default !== undefined) {
+			return schema.default;
+		}
+
+		if (schema.type) {
+			switch (schema.type) {
+				case 'object':
+					const obj: any = {};
+					if (schema.properties) {
+						for (const [propName, propSchema] of Object.entries(schema.properties)) {
+							const resolvedPropSchema = this.resolveRef(propSchema);
+							obj[propName] = this.generateExampleFromSchema(resolvedPropSchema);
+						}
+					}
+					return obj;
+				case 'array':
+					if (schema.items) {
+						const resolvedItemSchema = this.resolveRef(schema.items);
+						return [this.generateExampleFromSchema(resolvedItemSchema)];
+					}
+					return [];
+				case 'string':
+					if (schema.enum && schema.enum.length > 0) {
+						return schema.enum[0];
+					}
+					if (schema.format) {
+						return this.getExampleByFormat(schema.format);
+					}
+					return 'string';
+				case 'number':
+					return 0;
+				case 'integer':
+					return 0;
+				case 'boolean':
+					return true;
+				case 'null':
+					return null;
+				default:
+					return null;
+			}
+		}
+
+		if (schema.anyOf && schema.anyOf.length > 0) {
+			const resolvedSchema = this.resolveRef(schema.anyOf[0]);
+			return this.generateExampleFromSchema(resolvedSchema);
+		}
+
+		if (schema.oneOf && schema.oneOf.length > 0) {
+			const resolvedSchema = this.resolveRef(schema.oneOf[0]);
+			return this.generateExampleFromSchema(resolvedSchema);
+		}
+
+		if (schema.allOf && schema.allOf.length > 0) {
+			let result = {};
+			for (const subSchema of schema.allOf) {
+				const resolvedSubSchema = this.resolveRef(subSchema);
+				const subResult = this.generateExampleFromSchema(resolvedSubSchema);
+				result = { ...result, ...subResult };
+			}
+			return result;
+		}
+
+		return null;
+	}
+
+	private getExampleByFormat(format: string): any {
+		switch (format) {
+			case 'date-time':
+				return new Date().toISOString();
+			case 'email':
+				return 'user@example.com';
+			case 'uuid':
+				return '123e4567-e89b-12d3-a456-426614174000';
+			default:
+				return 'string';
+		}
+	}
+
+	private problemDetailsResponse(status: number, title: string, detail: string, errors?: string[]): Response {
+		const problemDetails = {
+			type: 'about:blank',
+			title,
+			status,
+			detail,
+			errors,
+		};
+		return new Response(JSON.stringify(problemDetails), {
+			status,
+			headers: { 'Content-Type': 'application/problem+json' },
+		});
+	}
+}

--- a/modules/utils.ts
+++ b/modules/utils.ts
@@ -45,7 +45,7 @@ export function getInvokeBinUrl(url: URL, binId: string) {
   return mockUrl;
 }
 
-const binRegEx = /^[0-9a-fA-F]{32}$/;
+const binRegEx = /^[0-9a-fA-F]{32}(_oas)?$/;
 
 export function validateBinId(binId: string) {
   return binRegEx.test(binId);

--- a/modules/zuplo.runtime.ts
+++ b/modules/zuplo.runtime.ts
@@ -15,25 +15,28 @@ export function runtimeInit(runtime: RuntimeExtensions) {
     );
   }
 
-  // This rewrites the URL of the request when the service is hosted
-  // with wildcard subdomains by taking the binId from the subdomain and
-  // adding it to the path. This way this app works for both hosting options
-  runtime.addRequestHook(async (request, context) => {
-    const url = new URL(request.url);
-    const parts = url.hostname.split(".");
-    // {binId}.api.mockbin.io
-    if (parts.length === 4) {
-      // Remove the binId from the hostname
-      url.hostname = url.hostname.substring(parts[0].length + 1);
-      // Add the binId to the path
-      url.pathname = `/${parts[0]}${url.pathname === "/" ? "" : url.pathname}`;
-    }
+  if (environment.USE_WILDCARD_SUBDOMAIN === "true") {
+    // This rewrites the URL of the request when the service is hosted
+    // with wildcard subdomains by taking the binId from the subdomain and
+    // adding it to the path. This way this app works for both hosting options
+    runtime.addRequestHook(async (request, context) => {
+      const url = new URL(request.url);
+      const parts = url.hostname.split(".");
+      // {binId}.api.mockbin.io
+      if (parts.length === 4) {
+        // Remove the binId from the hostname
+        url.hostname = url.hostname.substring(parts[0].length + 1);
+        // Add the binId to the path
+        url.pathname = `/${parts[0]}${url.pathname === "/" ? "" : url.pathname}`;
+      }
 
-    context.log.info(`Rewriting URL`, {
-      incoming: request.url,
-      rewritten: url.toString(),
+      context.log.info(`Rewriting URL`, {
+        incoming: request.url,
+        rewritten: url.toString(),
+      });
+      const newRequest = new ZuploRequest(url.toString(), request);
+      return newRequest;
     });
-    const newRequest = new ZuploRequest(url.toString(), request);
-    return newRequest;
-  });
+  }
+
 }


### PR DESCRIPTION
New OpenAPI support!

This is a pretty dirty but working version. 

* Uses the convention `_oas` to know what type of bin we're dealing with. May change that to use file metadata instead.
* Has a weird upload path `/v1/bins/openapi`
* JSON only right now, need js-yaml

To try it, drop this html into JSFiddle and upload a file

```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>File Upload to Mockbin</title>
</head>
<body>

    <h1>Upload File</h1>
    <form id="fileForm">
        <input type="file" id="fileInput" required>
        <button type="submit">Upload</button>
    </form>

    <p id="status"></p>

    <script>
        document.getElementById('fileForm').addEventListener('submit', async (event) => {
            event.preventDefault();

            const fileInput = document.getElementById('fileInput');
            if (fileInput.files.length === 0) {
                document.getElementById('status').innerText = "No file selected";
                return;
            }

            const file = fileInput.files[0];
            const formData = new FormData();
            formData.append('file', file);

            try {
                const response = await fetch('https://mockbin-main-d0c1f43.d2.zuplo.dev/v1/bins/openapi', {
                    method: 'POST',
                    body: formData,
                });

                if (response.ok) {
                    document.getElementById('status').innerText = `File uploaded successfully!
 ${await response.text()}`;
                } else {
                    document.getElementById('status').innerText = `Upload failed: ${response.statusText}`;
                }
            } catch (error) {
                document.getElementById('status').innerText = `Error: ${error.message}`;
            }
        });
    </script>

</body>
</html>
```

Then hit the Zup with `/{binId}/your-openapi-path`

Still bugs in mocking too but a start. 