### PR TITLE
[codex] Expand Mockbin DOM polyfill globals

### DIFF
--- a/modules/dom-parser-polyfill.ts
+++ b/modules/dom-parser-polyfill.ts
@@ -5,3 +5,28 @@ import xmldom from "./third-party/xmldom/index.js";
 if (typeof globalThis.DOMParser === "undefined") {
   globalThis.DOMParser = xmldom.DOMParser as typeof DOMParser;
 }
+
+if (typeof globalThis.Node === "undefined") {
+  globalThis.Node = xmldom.Node as typeof Node;
+}
+
+if (typeof globalThis.Element === "undefined") {
+  globalThis.Element = xmldom.Element as typeof Element;
+}
+
+if (typeof globalThis.Document === "undefined") {
+  globalThis.Document = xmldom.Document as typeof Document;
+}
+
+if (typeof globalThis.DocumentFragment === "undefined") {
+  globalThis.DocumentFragment =
+    xmldom.DocumentFragment as typeof DocumentFragment;
+}
+
+if (typeof globalThis.NodeList === "undefined") {
+  globalThis.NodeList = xmldom.NodeList as typeof NodeList;
+}
+
+if (typeof globalThis.XMLSerializer === "undefined") {
+  globalThis.XMLSerializer = xmldom.XMLSerializer as typeof XMLSerializer;
+}


### PR DESCRIPTION
## What changed
- expand the temporary Mockbin DOM polyfill to install `Node`, `Element`, `Document`, `DocumentFragment`, `NodeList`, and `XMLSerializer` in addition to `DOMParser`

## Why
The first workaround PR got the managed preview past `DOMParser is not defined`, but the live preview logs now show the next failure as `ReferenceError: Node is not defined` on `/v1/bins/:binId/requests`. This follows up on #80 and broadens the shim to match the DOM globals exposed by the bundled `xmldom` module.

## Validation
- verified locally that the polyfill now populates all expected globals from the bundled module
- preview evidence from Zuplo logs shows the managed failure moved from `DOMParser` to `Node`, so this targets the newly observed missing global

## Notes
- follow-up to #80
- this is still a temporary workaround pending a proper builder/runtime fix
