### PR TITLE
Add jiti to fix checkly v7 TypeScript config loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "checkly": "^7.15.0",
         "esbuild": "^0.24.0",
+        "jiti": "^2.7.0",
         "openapi-types": "^12.1.3",
         "prettier": "^3.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "checkly": "^7.15.0",
     "esbuild": "^0.24.0",
+    "jiti": "^2.7.0",
     "openapi-types": "^12.1.3",
     "prettier": "^3.0.3"
   }


### PR DESCRIPTION
## Summary
- Add `jiti` as a devDependency so Checkly v7 can load `checkly.config.ts`.

## Why
After the v4 → v7 Checkly upgrade, the Deploy Checks job started failing with:

```
Error: Unable to load the TypeScript file 'checkly.config.ts'.
An additional package is required to load TypeScript files.
The recommended TypeScript loader is jiti:
  npm install --save-dev jiti
```

v4 bundled a TS loader; v7 requires one explicitly. Adding `jiti` fixes the deploy.

## Test plan
- [ ] `npx checkly deploy` succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)