### PR TITLE
chore(deps): upgrade posthog-js to latest

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -13,7 +13,7 @@
         "lucide-react": "^0.456.0",
         "match-sorter": "6.3.3",
         "next": "14.1.1",
-        "posthog-js": "^1.88.1",
+        "posthog-js": "^1.383.0",
         "react": "^18",
         "react-dom": "^18",
         "uuid": "^9.0.1"
@@ -385,6 +385,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.30.11",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.30.11.tgz",
+      "integrity": "sha512-B4RB0d9cnaZlZ5ewEUh18HMO45tz6TkUPYTZA+8bTyszoIwNBkKSoJcBb2eF4ldcu37eXagkewVg2vWJ3+qTqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.383.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.383.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.383.0.tgz",
+      "integrity": "sha512-/x7Rf52IajI6DWTXN7wcoUDWK2JvqCVgusbnyfbMtfwVJnEQHCxu3DC9XEMoScpWp9Pgq1XgF0L97uwwn724mA==",
+      "license": "MIT"
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz",
@@ -445,6 +460,13 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
       "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/uuid": {
       "version": "9.0.6",
@@ -1107,6 +1129,17 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1242,6 +1275,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/downshift": {
@@ -3418,11 +3460,29 @@
       "dev": true
     },
     "node_modules/posthog-js": {
-      "version": "1.88.1",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.88.1.tgz",
-      "integrity": "sha512-+8kFFU5KIcFSm8zB3tX8l0GSPyq/OtMtdrS9dYpMJk6nsEwXvOjkwFEpSrYzL5eGEpTPdbM65M52HvMqqsjpXw==",
+      "version": "1.383.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.383.0.tgz",
+      "integrity": "sha512-94lTpimcl8tkhbnnfvyQNV3xFYQI2+rp4nl3zmWzNVPAG6aqipu78PWe72j8Gux51Y65ynOeuIoznK2Z4KZFsw==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "fflate": "^0.4.1"
+        "@posthog/core": "1.30.11",
+        "@posthog/types": "1.383.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -3467,6 +3527,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4296,6 +4362,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/www/package.json
+++ b/www/package.json
@@ -14,7 +14,7 @@
     "lucide-react": "^0.456.0",
     "match-sorter": "6.3.3",
     "next": "14.1.1",
-    "posthog-js": "^1.88.1",
+    "posthog-js": "^1.383.0",
     "react": "^18",
     "react-dom": "^18",
     "uuid": "^9.0.1"


### PR DESCRIPTION
Upgrades `posthog-js` in `www` to the latest release.

| Package | From | To |
|---------|------|----|
| `posthog-js` | ^1.88.1 | ^1.383.0 |

This is a large jump but stays within the `v1` major. The only usage (`www/pages/_app.tsx`: `posthog.init`, `posthog.debug`, `posthog.capture("$pageview")`, and `PostHogProvider` from `posthog-js/react`) relies on stable APIs that are unchanged across the v1 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)