### PR TITLE
Fix stack overflow when mocking circular `$ref` schemas

### DIFF
--- a/modules/mock-server.ts
+++ b/modules/mock-server.ts
@@ -485,10 +485,10 @@ export class MockServer {
       responseBody = mediaType.example;
     }
 
-    // Generate from schema if no example is available
+    // Generate from schema if no example is available. Pass the unresolved
+    // schema so a top-level $ref is seeded into the cycle guard.
     if (responseBody === null && mediaType.schema) {
-      const schema = this.resolveRef(mediaType.schema);
-      responseBody = this.generateExampleFromSchema(schema);
+      responseBody = this.generateExampleFromSchema(mediaType.schema);
     }
 
     // For non-JSON content types, ensure responseBody is a string

--- a/modules/mock-server.ts
+++ b/modules/mock-server.ts
@@ -278,12 +278,20 @@ export class MockServer {
     return errors;
   }
 
-  private resolveRef(obj: any): any {
+  private resolveRef(obj: any, seen: Set<string> = new Set()): any {
     if (!obj || !obj.$ref) {
       return obj;
     }
 
     const refPath = obj.$ref;
+    if (seen.has(refPath)) {
+      // Circular $ref chain (e.g. A -> B -> A) - stop resolving to avoid
+      // infinite recursion. Return the unresolved ref so callers degrade
+      // gracefully instead of overflowing the stack.
+      return obj;
+    }
+    seen.add(refPath);
+
     const parts = refPath.replace(/^#\//, "").split("/"); // Remove initial '#/' and split
     let refObj = this.openApiDoc;
 
@@ -297,7 +305,7 @@ export class MockServer {
 
     if (refObj.$ref) {
       // Recursively resolve nested $ref
-      return this.resolveRef(refObj);
+      return this.resolveRef(refObj, seen);
     } else {
       return refObj;
     }

--- a/modules/mock-server.ts
+++ b/modules/mock-server.ts
@@ -554,8 +554,18 @@ export class MockServer {
     return null;
   }
 
-  private generateExampleFromSchema(schema: any): any {
+  private generateExampleFromSchema(
+    schema: any,
+    refStack: Set<string> = new Set(),
+  ): any {
     if (!schema) return null;
+
+    const refPath = schema.$ref;
+    if (refPath) {
+      if (refStack.has(refPath)) return null;
+      refStack = new Set(refStack);
+      refStack.add(refPath);
+    }
 
     schema = this.resolveRef(schema);
 
@@ -584,16 +594,16 @@ export class MockServer {
             for (const [propName, propSchema] of Object.entries(
               schema.properties,
             )) {
-              const resolvedPropSchema = this.resolveRef(propSchema);
-              obj[propName] =
-                this.generateExampleFromSchema(resolvedPropSchema);
+              obj[propName] = this.generateExampleFromSchema(
+                propSchema,
+                refStack,
+              );
             }
           }
           return obj;
         case "array":
           if (schema.items) {
-            const resolvedItemSchema = this.resolveRef(schema.items);
-            return [this.generateExampleFromSchema(resolvedItemSchema)];
+            return [this.generateExampleFromSchema(schema.items, refStack)];
           }
           return [];
         case "string":
@@ -620,25 +630,22 @@ export class MockServer {
 
     if (schema.anyOf && schema.anyOf.length > 0) {
       // Pick a random schema from anyOf
-      const randomSchema = this.resolveRef(
-        schema.anyOf[Math.floor(Math.random() * schema.anyOf.length)],
-      );
-      return this.generateExampleFromSchema(randomSchema);
+      const randomSchema =
+        schema.anyOf[Math.floor(Math.random() * schema.anyOf.length)];
+      return this.generateExampleFromSchema(randomSchema, refStack);
     }
 
     if (schema.oneOf && schema.oneOf.length > 0) {
       // Pick a random schema from oneOf
-      const randomSchema = this.resolveRef(
-        schema.oneOf[Math.floor(Math.random() * schema.oneOf.length)],
-      );
-      return this.generateExampleFromSchema(randomSchema);
+      const randomSchema =
+        schema.oneOf[Math.floor(Math.random() * schema.oneOf.length)];
+      return this.generateExampleFromSchema(randomSchema, refStack);
     }
 
     if (schema.allOf && schema.allOf.length > 0) {
       let result = {};
       for (const subSchema of schema.allOf) {
-        const resolvedSubSchema = this.resolveRef(subSchema);
-        const subResult = this.generateExampleFromSchema(resolvedSubSchema);
+        const subResult = this.generateExampleFromSchema(subSchema, refStack);
         result = { ...result, ...subResult };
       }
       return result;

--- a/tests/mock-server.test.ts
+++ b/tests/mock-server.test.ts
@@ -1,5 +1,5 @@
 import { MockServer } from "../modules/mock-server"; // Adjust the path as needed
-import { describe, test, assert } from "vitest";
+import { describe, test, assert, expect } from "vitest";
 import json from "./pizza.oas.json";
 
 // OpenAPI document
@@ -330,6 +330,58 @@ describe("MockServer Tests for Pizza API", () => {
       const responseBody = await response.text();
       assert.ok(responseBody);
       // Further assertions can be made based on the default content type and response
+    });
+  });
+
+  describe("Circular Schema Tests", () => {
+    const circularDoc = {
+      openapi: "3.0.0",
+      info: { title: "Circular Test", version: "1.0.0" },
+      paths: {
+        "/nodes": {
+          get: {
+            responses: {
+              "200": {
+                description: "OK",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Node" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Node: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+              next: { $ref: "#/components/schemas/Node" },
+            },
+          },
+        },
+      },
+    };
+    const circularMockServer = new MockServer(circularDoc);
+
+    test("Should return 200 without stack overflow for circular $ref schemas", async () => {
+      const request = new Request("http://localhost/nodes", {
+        method: "GET",
+      });
+      const response = await circularMockServer.handleRequest(request);
+      assert.strictEqual(response.status, 200);
+      expect(await response.json()).toMatchInlineSnapshot(`
+        {
+          "next": {
+            "next": null,
+            "value": "string",
+          },
+          "value": "string",
+        }
+      `);
     });
   });
 

--- a/tests/mock-server.test.ts
+++ b/tests/mock-server.test.ts
@@ -375,10 +375,62 @@ describe("MockServer Tests for Pizza API", () => {
       assert.strictEqual(response.status, 200);
       expect(await response.json()).toMatchInlineSnapshot(`
         {
-          "next": {
-            "next": null,
-            "value": "string",
+          "next": null,
+          "value": "string",
+        }
+      `);
+    });
+
+    // Regression: the real-world trigger was a cycle through array items
+    // (e.g. Comment.replies[] -> Comment), a different recursion path than a
+    // direct object property.
+    const arrayCycleDoc = {
+      openapi: "3.0.0",
+      info: { title: "Array Cycle Test", version: "1.0.0" },
+      paths: {
+        "/trees": {
+          get: {
+            responses: {
+              "200": {
+                description: "OK",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Tree" },
+                  },
+                },
+              },
+            },
           },
+        },
+      },
+      components: {
+        schemas: {
+          Tree: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+              children: {
+                type: "array",
+                items: { $ref: "#/components/schemas/Tree" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const arrayCycleMockServer = new MockServer(arrayCycleDoc);
+
+    test("Should return 200 without stack overflow for cycles through array items", async () => {
+      const request = new Request("http://localhost/trees", {
+        method: "GET",
+      });
+      const response = await arrayCycleMockServer.handleRequest(request);
+      assert.strictEqual(response.status, 200);
+      expect(await response.json()).toMatchInlineSnapshot(`
+        {
+          "children": [
+            null,
+          ],
           "value": "string",
         }
       `);

--- a/tests/mock-server.test.ts
+++ b/tests/mock-server.test.ts
@@ -383,6 +383,45 @@ describe("MockServer Tests for Pizza API", () => {
         }
       `);
     });
+
+    const indirectCircularDoc = {
+      openapi: "3.0.0",
+      info: { title: "Indirect Circular Test", version: "1.0.0" },
+      paths: {
+        "/a": {
+          get: {
+            responses: {
+              "200": {
+                description: "OK",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/A" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          // A and B are pure $refs pointing at each other, so resolveRef()
+          // itself would recurse forever without a cycle guard.
+          A: { $ref: "#/components/schemas/B" },
+          B: { $ref: "#/components/schemas/A" },
+        },
+      },
+    };
+    const indirectCircularMockServer = new MockServer(indirectCircularDoc);
+
+    test("Should return 200 without stack overflow for indirect circular $ref chains", async () => {
+      const request = new Request("http://localhost/a", {
+        method: "GET",
+      });
+      const response = await indirectCircularMockServer.handleRequest(request);
+      assert.strictEqual(response.status, 200);
+      expect(await response.json()).toBeNull();
+    });
   });
 
   // Error Tests


### PR DESCRIPTION
Generating a mock response from a schema with a self-referential `$ref` (e.g. `Shipment.comments` to `Comment.replies` to `Comment`) recursed forever and returned a 500 "Maximum call stack size exceeded".

This adds a cycle guard that tracks visited `$ref`s along the current branch and cuts the recursion with `null` when a ref repeats.